### PR TITLE
style: separate progress and life bars

### DIFF
--- a/deneme1.html
+++ b/deneme1.html
@@ -117,18 +117,36 @@
       display: inline-block;
     }
 
+    #statusContainer {
+      display: flex;
+      flex-direction: column;
+      align-items: flex-start;
+    }
+
+    #lifeBarContainer {
+      height: 24px;
+      margin-top: 10px;
+    }
+
 
 
   </style>
 </head>
 <body>
-  <div id="progressBar" style="display: flex; gap: 20px; margin: 20px 0 40px 0;">
-    <div class="step" id="step1">🔹 Intro</div>
-    <div class="step" id="step2">📏 Slab</div>
-    <div class="step" id="step3">📊 Loads</div>
-    <div class="step" id="step4">📐 Width</div>
-    <div class="step" id="step5">⚖️ Design Load</div>
-    <div class="step" id="step6">🎓 Summary</div> 
+  <div id="statusContainer">
+    <div id="progressBar" style="display: flex; gap: 20px; margin: 20px 0 0 0;">
+      <div class="step" id="step1">🔹 Intro</div>
+      <div class="step" id="step2">📏 Slab</div>
+      <div class="step" id="step3">📊 Loads</div>
+      <div class="step" id="step4">📐 Width</div>
+      <div class="step" id="step5">⚖️ Design Load</div>
+      <div class="step" id="step6">🎓 Summary</div>
+    </div>
+    <div id="lifeBarContainer">
+      <span>❤️</span>
+      <span>❤️</span>
+      <span>❤️</span>
+    </div>
   </div>
 
   <style>


### PR DESCRIPTION
## Summary
- Wrap progress and life indicators in a new container for flexible layout
- Add dedicated styling to life bar so it stays separated from the progress bar

## Testing
- `npx playwright --version` *(fails: 403 Forbidden - GET https://registry.npmjs.org/playwright)*

------
https://chatgpt.com/codex/tasks/task_e_68a758301458832db8073c001246039b